### PR TITLE
Optionalizing platform_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,7 @@ resource aws_ecs_service service {
   name                               = var.name
   cluster                            = var.cluster_name
   launch_type                        = var.launch_type
+  platform_version                   = var.platform_version
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.desired_count
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent

--- a/variables.tf
+++ b/variables.tf
@@ -255,3 +255,8 @@ variable scaling_threshold {
   description = "The desired value for the `scaling_metric`. Defaults to 70%."
   default     = 70
 }
+
+variable platform_version {
+  description = "The platform version on which to run your service. Only applicable for launch_type set to FARGATE. Defaults to LATEST."
+  default = "LATEST"
+  }

--- a/variables.tf
+++ b/variables.tf
@@ -258,5 +258,5 @@ variable scaling_threshold {
 
 variable platform_version {
   description = "The platform version on which to run your service. Only applicable for launch_type set to FARGATE. Defaults to LATEST."
-  default = "LATEST"
-  }
+  default     = "LATEST"
+}


### PR DESCRIPTION
Since ECS is upgrading to version 1.4.0, I thought it a great time to also put in a pull-request for setting the platform_version var. Both for others' backwards compatibility as much as providing the possibility to do forward-testing, by setting the version to 1.4.0 already.

We can modify the variables.tf and add in the default of LATEST, which it already is. The module itself however, can then also support setting different versions.

I've already supplied it in the PR.