### PR TITLE
Separates execution and task role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,7 @@ EOF
 }
 
 /**
- * Generates the a default Policy for the ECS Container
+ * Generates a default Policy for the ECS Container
  */
 resource aws_iam_role_policy ecs_execution_default_policy {
   count = var.use_execution_role ? 1 : 0
@@ -295,7 +295,7 @@ EOF
 }
 
 /**
- * Generates the Policy for the ECS Container
+ * Generates a policy for the execution role to provide access to the given Cloudwatch Log stream.
  */
 resource aws_iam_role_policy ecs_execution_log_policy {
   count = var.use_execution_role && var.cloudwatch_log_group_arn != null ? 1 : 0
@@ -321,7 +321,7 @@ EOF
 }
 
 /**
- * Generates the Role for the ECS Container
+ * Generates a Task Role for the ECS Task.
  */
 resource aws_iam_role ecs_task_role {
   count = var.use_task_role ? 1 : 0

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,11 @@
-output ecs_iam_role_id {
-  description = "The ID for the IAM Role attached to the Service."
-  value       = aws_iam_role.ecs_execution_role.id
+output ecs_execution_role_id {
+  description = "The ID for the Task Execution Role attached to the Service."
+  value       = var.use_execution_role ? aws_iam_role.ecs_execution_role[0].id : null
+}
+
+output ecs_task_role_id {
+  description = "The ID for the Task Execution Role attached to the Service."
+  value       = var.use_task_role ? aws_iam_role.ecs_task_role[0].id : null
 }
 
 output security_group_id {

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable task_cpu {
 
 variable task_volumes {
   description = "A set of volume blocks that containers in your task may use."
-  type        = set(object({ name: string, host_path: string }))
+  type        = set(object({ name : string, host_path : string }))
   default     = []
 }
 
@@ -229,12 +229,32 @@ EOT
   default = 120
 }
 
-# Secrets
-variable secrets_policy_arns {
-  description = "The ARNs of IAM Policies that grants the Service access to one or more SecretsManager Secrets."
+# Policies
+variable use_task_role {
+  description = "Whether or not a default Task Role should be created for this task. Policy ARNS can be supplied to attach policies to the generated role."
+  type        = bool
+  default     = true
+}
+
+variable task_role_policy_arns {
+  description = "The ARNs of any additional IAM Policies that should be attached to the ECS Task Role."
   type        = list(string)
   default     = []
 }
+
+variable use_execution_role {
+  description = "Whether or not a default Task Execution Role should be created for this task. Policy ARNS can be supplied to attach policies to the generated role."
+  type        = bool
+  default     = true
+}
+
+variable execution_role_policy_arns {
+  description = "The ARNs of any additional IAM Policies that should be attached to the ECS Execution Role."
+  type        = list(string)
+  default     = []
+}
+
+
 
 # ECS Auto Scaling
 variable enable_auto_scaling {


### PR DESCRIPTION
This module was unintentionally generating and using the same role for both the Task Role and the Execution Role. This separates these two out.

In cases where you're deploying with `launch_type = EC2`, you may already have a role on the instances and do not need these roles. So this PR will make these roles optional.

Lastly, each can have policies ARNs passed in to be attached to the respective roles.