### PR TITLE
Fixes IAM Policy for Cloudwatch Log Group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,7 +313,7 @@ resource aws_iam_role_policy ecs_execution_log_policy {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "${var.cloudwatch_log_group_arn}"
+      "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*}",
     }
   ]
 }


### PR DESCRIPTION
With version `>=3.0` of the AWS provider, the ARN of a Cloudwatch Log Group resource has had the trailing `:*` removed, which causes the generated iam policy for the execution role to be generated incorrectly. This fix handles both ARNs from before and after `>=3.0`.

Fixes #8 