### PR TITLE
Add capacity_provider_strategies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ resource aws_ecs_task_definition task {
 resource aws_ecs_service service {
   name                               = var.name
   cluster                            = var.cluster_name
-  launch_type                        = var.launch_type
+  launch_type                        = length(var.capacity_provider_strategies) > 0 ? null : var.launch_type
   scheduling_strategy                = var.scheduling_strategy
   platform_version                   = var.platform_version
   task_definition                    = aws_ecs_task_definition.task.arn
@@ -127,6 +127,15 @@ resource aws_ecs_service service {
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   deployment_maximum_percent         = var.deployment_maximum_percent
 
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity_provider_strategies
+    content {
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+      base              = lookup(capacity_provider_strategy.value, "base", null)
+    }
+  }
+  
   dynamic "ordered_placement_strategy" {
     for_each = var.launch_type == "FARGATE" || var.scheduling_strategy == "DAEMON" ? [] : [1]
 

--- a/main.tf
+++ b/main.tf
@@ -297,7 +297,7 @@ resource aws_iam_role_policy ecs_execution_default_policy {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*}",
+      "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*}"
     }
     %{ endif }
   ]

--- a/main.tf
+++ b/main.tf
@@ -289,25 +289,8 @@ resource aws_iam_role_policy ecs_execution_default_policy {
         "ecr:BatchGetImage"
       ],
       "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-/**
- * Generates a policy for the execution role to provide access to the given Cloudwatch Log stream.
- */
-resource aws_iam_role_policy ecs_execution_log_policy {
-  count = var.use_execution_role && var.cloudwatch_log_group_arn != null ? 1 : 0
-
-  name = "${var.cluster_name}-${var.name}-cloudwatch-log-policy"
-  role = aws_iam_role.ecs_execution_role[0].id
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
+    },
+    %{ if var.cloudwatch_log_group_arn != null }
     {
       "Effect": "Allow",
       "Action": [
@@ -316,6 +299,7 @@ resource aws_iam_role_policy ecs_execution_log_policy {
       ],
       "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*}",
     }
+    %{ endif }
   ]
 }
 EOF

--- a/main.tf
+++ b/main.tf
@@ -297,7 +297,7 @@ resource aws_iam_role_policy ecs_execution_default_policy {
         "logs:CreateLogStream",
         "logs:PutLogEvents"
       ],
-      "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*}"
+      "Resource": "${replace(var.cloudwatch_log_group_arn, "/:\\*$/", "")}:*"
     }
     %{ endif }
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -292,3 +292,13 @@ variable platform_version {
   description = "The platform version on which to run your service. Only applicable for launch_type set to FARGATE. Defaults to LATEST."
   default     = "LATEST"
 }
+
+variable "capacity_provider_strategies" {
+  type = list(object({
+    capacity_provider = string
+    weight            = number
+    base              = number
+  }))
+  description = "The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy"
+  default     = []
+}


### PR DESCRIPTION
The current code does not support setting `capacity_provider_strategies`.

We've had this code in our production for a while already but never returned this commit back into mainline, so here we are giving back 👍 