### PR TITLE
Allow custom service discovery name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -194,7 +194,7 @@ resource aws_ecs_service service {
 resource aws_service_discovery_service sds {
   count = var.enable_service_discovery ? 1 : 0
 
-  name = var.name
+  name = var.service_discovery_service_name != null ? var.service_discovery_service_name : var.name
 
   dns_config {
     namespace_id = var.service_discovery_namespace_id

--- a/variables.tf
+++ b/variables.tf
@@ -185,6 +185,12 @@ variable service_discovery_namespace_id {
   default     = null
 }
 
+variable service_discovery_service_name {
+  description = "The name of service to use for DNS configuration."
+  type        = string
+  default     = null
+}
+
 variable service_discovery_dns_record_type {
   description = "The type of the resource, which indicates the value that Amazon Route 53 returns in response to DNS queries. One of `A` or `SRV`."
   type        = string


### PR DESCRIPTION
Hi,

added an option to allow configuring a SD name different from the service name.

Kind regards,
Peter